### PR TITLE
Fix: Ensure slide content visibility after PDF download interaction

### DIFF
--- a/app.js
+++ b/app.js
@@ -219,7 +219,14 @@ class PresentationApp {
                 if (!originalTrainerMode && this.trainerMode) {
                     this.toggleTrainerMode();
                 }
+
+                // Ensure the correct slide is displayed
+                this.goToSlide(this.currentSlide);
+
             }, 1000);
+        } else {
+            // If user cancels, still ensure the correct slide is displayed
+            this.goToSlide(this.currentSlide);
         }
     }
 


### PR DESCRIPTION
Modified the `downloadPDF` function in `app.js` to call `this.goToSlide(this.currentSlide)` after the print dialog interaction (both on confirmation and cancellation).

This ensures that the correct slide's visibility and active state are properly restored, addressing an issue where slide content might not be displayed after attempting to use the PDF download feature.